### PR TITLE
Vignette: link the browser bullet at the new docs/match/ Match app

### DIFF
--- a/vignettes/bio-env-matching.Rmd
+++ b/vignettes/bio-env-matching.Rmd
@@ -42,7 +42,7 @@ the *same engine* on:
 | **R**, on your laptop | this vignette |
 | **Python**, on a notebook server | `import duckdb; con.sql(open('q.sql').read()).df()` |
 | **shell**, on the command line | `duckdb < q.sql` |
-| **a web browser** | [shell.duckdb.org](https://shell.duckdb.org) — DuckDB-WASM, paste the same SQL, no install |
+| **a web browser**, no install | [**CalCOFI Match**](https://calcofi.io/docs/match/) — point-and-click form for the three wrappers + custom SQL, runs DuckDB-WASM client-side. Or [shell.duckdb.org](https://shell.duckdb.org) for free-form SQL. |
 
 Below we ask one cross-domain question — *how did Pacific sardine larvae
 experience the 2014–2016 marine heatwave?* — answer it with a single
@@ -245,9 +245,14 @@ duckdb -c "INSTALL httpfs; LOAD httpfs; INSTALL spatial; LOAD spatial;
 $(cat sardine_match.sql)"
 ```
 
-**A web browser, no install** — paste the same SQL into
-[shell.duckdb.org](https://shell.duckdb.org). It runs in DuckDB-WASM, in
-JavaScript, against the same public GCS bucket. Try it on a phone if you like.
+**A web browser, no install** — open [**CalCOFI Match**](https://calcofi.io/docs/match/),
+pick a tab (by name / by taxon / zoo biomass / custom / SQL shell), fill the
+form, hit **Run**. The page loads
+[DuckDB-WASM](https://duckdb.org/docs/api/wasm/overview.html) in a worker
+thread, runs the *exact same* generated SQL (it imports a JavaScript port of
+`calcofi4r/R/match.R`), and renders the rows — all client-side. For arbitrary
+ad-hoc SQL with no UI at all, [shell.duckdb.org](https://shell.duckdb.org) is
+DuckDB's official WASM shell. Try either on a phone if you like.
 
 ## Version pinning for archival reproducibility
 


### PR DESCRIPTION
The bio-env-matching vignette's "Run it from anywhere" pitch and the matching detailed section both pointed the **browser** path at [shell.duckdb.org](https://shell.duckdb.org) — generic, no CalCOFI context. The new [docs/match/](https://calcofi.io/docs/match/) DuckDB-WASM app (companion PR: [`CalCOFI/docs#PR-pending`](https://github.com/CalCOFI/docs/pull/)) is the client-side mirror of the three retired Plumber endpoints, with the form pre-populated for this vignette's worked example.

Two two-line edits:
- The top-of-vignette 4-row table now points "a web browser, no install" at the Match app, with shell.duckdb.org noted as a fallback for free-form SQL.
- The "Run it from anywhere" detailed section now describes opening the Match app, picking a tab, hitting Run — and notes the page imports a JavaScript port of `calcofi4r/R/match.R` so the same generated SQL runs there.

No chunk / dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)