### PR TITLE
Vignette: relink browser bullets to calcofi.io/query/

### DIFF
--- a/vignettes/bio-env-matching.Rmd
+++ b/vignettes/bio-env-matching.Rmd
@@ -42,7 +42,7 @@ the *same engine* on:
 | **R**, on your laptop | this vignette |
 | **Python**, on a notebook server | `import duckdb; con.sql(open('q.sql').read()).df()` |
 | **shell**, on the command line | `duckdb < q.sql` |
-| **a web browser**, no install | [**CalCOFI Match**](https://calcofi.io/docs/match/) — point-and-click form for the three wrappers + custom SQL, runs DuckDB-WASM client-side. Or [shell.duckdb.org](https://shell.duckdb.org) for free-form SQL. |
+| **a web browser**, no install | [**CalCOFI Query**](https://calcofi.io/query/) — left-side accordion of point-and-click forms (the three bio↔env wrappers + custom SQL + a free-form SQL shell + simple browse / spatial / temporal / per-dataset queries), all running DuckDB-WASM client-side. Or [shell.duckdb.org](https://shell.duckdb.org) for free-form SQL without CalCOFI context. |
 
 Below we ask one cross-domain question — *how did Pacific sardine larvae
 experience the 2014–2016 marine heatwave?* — answer it with a single
@@ -245,7 +245,7 @@ duckdb -c "INSTALL httpfs; LOAD httpfs; INSTALL spatial; LOAD spatial;
 $(cat sardine_match.sql)"
 ```
 
-**A web browser, no install** — open [**CalCOFI Match**](https://calcofi.io/docs/match/),
+**A web browser, no install** — open [**CalCOFI Query**](https://calcofi.io/query/),
 pick a tab (by name / by taxon / zoo biomass / custom / SQL shell), fill the
 form, hit **Run**. The page loads
 [DuckDB-WASM](https://duckdb.org/docs/api/wasm/overview.html) in a worker


### PR DESCRIPTION
The browser-only DuckDB-WASM playground moved from \`calcofi.io/docs/match/\` to its own dedicated home at **[calcofi.io/query/](https://calcofi.io/query/)** (repo: [CalCOFI/query](https://github.com/CalCOFI/query)) — dark theme by default, vertical left-side accordion nav, an intro page, and a file-per-query framework that's easy to extend. Two browser-bullet edits in the vignette to point there:

1. Top-of-vignette "Where / How" table — browser row now points at \`calcofi.io/query/\` and notes the wider catalog (the three bio↔env wrappers + custom SQL + a free-form SQL shell + simple browse / spatial / temporal / per-dataset queries).
2. Detailed "A web browser, no install" paragraph — same URL swap.

\`shell.duckdb.org\` is still mentioned as a fallback for free-form SQL without CalCOFI context. No chunk / dependency changes.

Companion: [CalCOFI/docs#9](https://github.com/CalCOFI/docs/pull/9) (redirect stub + cross-reference URL update across data-access / helpers / api).

🤖 Generated with [Claude Code](https://claude.com/claude-code)